### PR TITLE
Add contain overload for checking if set contains another set

### DIFF
--- a/include/UtilsCPP/Set.hpp
+++ b/include/UtilsCPP/Set.hpp
@@ -146,7 +146,7 @@ public:
         UniquePtr<Node>& node = it.m_node->parent == nullptr ? m_root : (it.m_node->parent->right == it.m_node ? it.m_node->parent->right : it.m_node->parent->left);
         if (node->left == nullptr && node->right == nullptr)
             node.clear();
-        else if (node->left == nullptr && node->right != nullptr || node->right == nullptr && node->left != nullptr)
+        else if ((node->left == nullptr && node->right != nullptr) || (node->right == nullptr && node->left != nullptr))
         {
             UniquePtr<Node> tmp = std::move(node->left == nullptr ? node->right : node->left);
             tmp->parent = node->parent;

--- a/include/UtilsCPP/Set.hpp
+++ b/include/UtilsCPP/Set.hpp
@@ -137,6 +137,16 @@ public:
     template<typename Y>
     inline bool contain(const Y& value) const { return find(value) != end(); }
 
+    inline bool contain(const Set& other) const
+    {
+        for (const auto& element : other)
+        {
+            if (contain(element) == false)
+                return false;
+        }
+        return true;
+    }
+
     inline void clear() { m_root.clear(); }
 
     void remove(const Iterator& it)
@@ -290,6 +300,14 @@ public:
     {
         Set newSet = *this;
         newSet.remove(newSet.find(value));
+        return newSet;
+    }
+
+    Set operator + (const Set& other) const
+    {
+        Set newSet = *this;
+        for (const auto& element : *this)
+            newSet.insert(element);
         return newSet;
     }
 


### PR DESCRIPTION
This pull request includes a commit that fixes formatting in the Set.hpp file and adds an overload for the `contain` function in the `Set` class. The new overload allows checking if a set contains another set.